### PR TITLE
Empty records

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -3,3 +3,9 @@ let upstream =
         sha256:f91d36c7e4793fe4d7e042c57fef362ff3f9e9ba88454cd38686701e30bf545a
 
 in  upstream
+
+with dts =
+  { repo = "https://github.com/thought2/purescript-dts.git"
+  , version = "973692ff220694d6f75df57025bb846362747cdf"
+  , dependencies = [ "arrays", "console", "effect", "maybe", "newtype", "ordered-collections", "ordered-set", "prelude", "tuples" ]
+  }

--- a/test/TsBridgeSpec.purs
+++ b/test/TsBridgeSpec.purs
@@ -243,6 +243,9 @@ spec = do
         testTypePrint (tsBridge (Proxy :: _ { bar :: String, foo :: Number }))
           "{ readonly 'bar': string; readonly 'foo': number; }"
 
+        testTypePrint (tsBridge (Proxy :: _ { }))
+          "Record<string, never>"
+
       describe "Maybe" do
         testTypePrint (tsBridge (Proxy :: _ (Maybe Boolean)))
           "import('../Data.Maybe').Maybe<boolean>"
@@ -318,6 +321,22 @@ spec = do
             )
 
       describe "TsRecord" do
+        it "should work with an empty TsRecord" do
+          shouldEqual
+            ( TSB.tsProgram
+                [ TSB.tsModuleFile "Foo.Bar"
+                    [ TSB.tsTypeAlias Tok "SomeRecord"
+                        (Proxy :: _ (TsRecord ()))
+                    ]
+                ]
+                <#> printTsProgram
+            )
+            ( Right $ Map.fromFoldable
+                [ textFile "Foo.Bar/index.d.ts"
+                    [ "export type SomeRecord = Record<string, never>"
+                    ]
+                ]
+            )
         it "should work with no modifiers" do
           shouldEqual
             ( TSB.tsProgram

--- a/test/TsBridgeSpec.purs
+++ b/test/TsBridgeSpec.purs
@@ -243,7 +243,7 @@ spec = do
         testTypePrint (tsBridge (Proxy :: _ { bar :: String, foo :: Number }))
           "{ readonly 'bar': string; readonly 'foo': number; }"
 
-        testTypePrint (tsBridge (Proxy :: _ { }))
+        testTypePrint (tsBridge (Proxy :: _ {}))
           "Record<string, never>"
 
       describe "Maybe" do

--- a/test/TsBridgeSpec.purs
+++ b/test/TsBridgeSpec.purs
@@ -314,7 +314,7 @@ spec = do
                         [ "export type RecListStr = "
                         , "({ readonly 'type': 'cons'; readonly 'value': { readonly 'head': string; readonly 'tail': import('../Data.RecListStr').RecListStr; }; })"
                         , " | "
-                        , "({ readonly 'type': 'nil'; readonly 'value': {}; })"
+                        , "({ readonly 'type': 'nil'; readonly 'value': Record<string, never>; })"
                         ]
                     ]
                 ]


### PR DESCRIPTION
Changed the [dts](https://github.com/thought2/purescript-dts/commit/973692ff220694d6f75df57025bb846362747cdf) packafe for this.

Empty records are now treated as `Record<string, never>`

should close https://github.com/thought2/purescript-ts-bridge/issues/10